### PR TITLE
clonecli6.py: message key must be prefixed with subtree string

### DIFF
--- a/examples/Python/clonecli6.py
+++ b/examples/Python/clonecli6.py
@@ -22,7 +22,7 @@ def main():
     try:
         while True:
             # Distribute as key-value message
-            key = b"%d" % random.randint(1,10000)
+            key = b"%s%d" % (clone.subtree, random.randint(1,10000))
             value = b"%d" % random.randint(1,1000000)
             clone.set(key, value, random.randint(0,30))
             time.sleep(1)


### PR DESCRIPTION
This matches the behavior of the c example:

``` c
    //  Set random tuples into the distributed hash
    while (!zctx_interrupted) {
        //  Set random value, check it was stored
        char key [255];
        char value [10];
        sprintf (key, "%s%d", SUBTREE, randof (10000));
        sprintf (value, "%d", randof (1000000));
        clone_set (clone, key, value, randof (30));
        sleep (1);
```
